### PR TITLE
new rustecal configuration added

### DIFF
--- a/otterdog/eclipse-ecal.jsonnet
+++ b/otterdog/eclipse-ecal.jsonnet
@@ -202,7 +202,7 @@ orgs.newOrg('automotive.ecal', 'eclipse-ecal') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
-      description: "Rust bindings to the Continental eCAL API",
+      description: "Rust bindings to the Eclipse eCAL API",
       web_commit_signoff_required: false,
       workflows+: {
         default_workflow_permissions: "write",
@@ -210,6 +210,40 @@ orgs.newOrg('automotive.ecal', 'eclipse-ecal') {
       secrets: [
         orgs.newRepoSecret('CRATES_IO_TOKEN') {
           value: "********",
+        },
+      ],
+    },
+    orgs.newRepo('rustecal') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "Idiomatic Rust bindings for eCAL.",
+      homepage: "https://github.com/eclipse-ecal/rustecal",
+      topics+: [
+        "rust",
+        "ipc",
+        "middleware",
+        "publish-subscribe",
+        "client-server",
+        "ecal",
+        "ffi",
+        "interprocess-communication"
+      ],
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+      secrets: [
+        orgs.newRepoSecret('CRATES_IO_TOKEN') {
+          value: "********",
+        },
+      ],
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: 0,
+          requires_linear_history: true,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
         },
       ],
     },


### PR DESCRIPTION
## Add rustecal repository to eclipse-ecal Otterdog configuration

This PR adds the new repository [`rustecal`](https://github.com/eclipse-ecal/rustecal) to the `eclipse-ecal.jsonnet` configuration. `rustecal` is a set of idiomatic Rust bindings for the Eclipse-eCAL middleware and is now part of the official GitHub organization.

### Changes

- Registered `rustecal` in the `_repositories+::` list.
- Included metadata such as description, homepage, topics, and default branch.
- Applied standard repository settings and branch protection rules (`main`).
- Added placeholder for `CRATES_IO_TOKEN` secret to support potential CI-based publication to [crates.io](https://crates.io).

### Notes

- This change ensures `rustecal` is fully managed by Otterdog and kept in sync with organization policies.
- No immediate workflow or secret values are changed—only structure and registration.

Please review and approve the addition. Thanks!
